### PR TITLE
Add background image to Parkland header

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.3
+          ruby-version: 3.1.2
           bundler-cache: true
 
       - name: Install dependencies

--- a/app/models/header.rb
+++ b/app/models/header.rb
@@ -6,4 +6,8 @@ class Header < ApplicationRecord
   validates :title, presence: true
   validates :welcome, presence: true
   validates :background_image, content_type: ["image/png", "image/jpeg", "image/jpg"], max_file_size: 10.megabytes
+
+  def self.active_header_with_background?
+    first && first.background_image.attached?
+  end
 end

--- a/app/views/layouts/themes/parkland.html.erb
+++ b/app/views/layouts/themes/parkland.html.erb
@@ -47,7 +47,12 @@
       -->
 
       <section class="w-full h-screen relative">
-        <%= image_tag "sabrehill-header-background.jpg", class: "object-cover h-screen w-full" %>
+        <% if @website.headers.active_header_with_background? %>
+          <%= image_tag @website.headers.first.background_image, class: "object-cover h-screen w-full" %>
+        <% else %>
+          <%= image_tag "sabrehill-header-background.jpg", class: "object-cover h-screen w-full" %>
+        <% end %>
+
         <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 p-4 xl:px-0 w-3/4">
           <div class="px-16 py-4 mx-auto w-full text-center text-white">
             <p class="text-xl uppercase">Welcome to</p>

--- a/test/models/header_test.rb
+++ b/test/models/header_test.rb
@@ -48,4 +48,14 @@ class HeaderTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "returns true if the active header has a background image" do
+    website = websites(:mapleshore)
+    assert_equal true, website.headers.active_header_with_background?
+  end
+
+  test "returns false if the active header does not have a background image" do
+    website = websites(:drew_lang)
+    assert_equal false, website.headers.active_header_with_background?
+  end
 end


### PR DESCRIPTION
## Proposed Changes

- Add the background image to the header
  
Closes #12 - Integrate header background image into theme
