### PR TITLE
Add component for sub-title in desert theme

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -247,6 +249,8 @@ GEM
     stimulus-rails (1.1.0)
       railties (>= 6.0.0)
     strscan (3.0.4)
+    tailwindcss-rails (2.0.12-arm64-darwin)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.0.12-x86_64-darwin)
       railties (>= 6.0.0)
     tailwindcss-rails (2.0.12-x86_64-linux)
@@ -284,6 +288,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-19
   x86_64-linux
 

--- a/app/components/admin/error_message_component.html.erb
+++ b/app/components/admin/error_message_component.html.erb
@@ -1,10 +1,10 @@
-<div class="w-full sm:rounded-lg sm:shadow-sm p-4 bg-red-100">
+<div class="w-full p-4 bg-red-100 sm:rounded-lg sm:shadow-sm">
   <div class="flex flex-col">
     <h3 class="text-sm font-medium red">
       <%= I18n.t "errors.messages.not_saved", count: @errors.count, resource: @resource.class.model_name.human.downcase %>
     </h3>
 
-    <div class="text-sm flex-1 md:flex md:justify-between">
+    <div class="flex-1 text-sm md:flex md:justify-between">
       <%= content_tag(:ul, role: "list", class: "list-disc space-y-1 mt-2 pl-5") do %>
         <% @errors.each do |message| %>
           <%= content_tag(:li, message) %>

--- a/app/components/themes/desert/sub_title_component.html.erb
+++ b/app/components/themes/desert/sub_title_component.html.erb
@@ -1,0 +1,3 @@
+<p class="mt-4 text-lg tracking-tight text-gray-500 heading">
+  <%= @sub_title %>
+</p>

--- a/app/components/themes/desert/sub_title_component.rb
+++ b/app/components/themes/desert/sub_title_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Themes::Desert::SubTitleComponent < ViewComponent::Base
+  def initialize(sub_title:)
+    @sub_title = sub_title
+  end
+
+  def render?
+    @sub_title.present?
+  end
+end

--- a/test/components/themes/desert/sub_title_component_test.rb
+++ b/test/components/themes/desert/sub_title_component_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Themes::Desert::SubTitleComponentTest < ViewComponent::TestCase
+  test "renders when sub-title is present" do
+    sub_title = "All the recent news from your golf club"
+    assert_match(
+      /All the recent news from your golf club/,
+      render_inline(Themes::Desert::SubTitleComponent.new(sub_title: sub_title)).to_html
+    )
+  end
+end


### PR DESCRIPTION
## Proposed Changes

- Add a sub-title component for the desert theme that can be reused across multiple components for the theme.
  
Closes #62 
