### PR TITLE
Add component for sub-title in parkland theme

### DIFF
--- a/app/components/themes/parkland/sub_title_component.html.erb
+++ b/app/components/themes/parkland/sub_title_component.html.erb
@@ -1,0 +1,3 @@
+<p class="mt-3 text-xl text-gray-500">
+  <%= @sub_title %>
+</p>

--- a/app/components/themes/parkland/sub_title_component.rb
+++ b/app/components/themes/parkland/sub_title_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Themes::Parkland::SubTitleComponent < ViewComponent::Base
+  def initialize(sub_title:)
+    @sub_title = sub_title
+  end
+
+  def render?
+    @sub_title.present?
+  end
+end

--- a/test/components/themes/parkland/sub_title_component_test.rb
+++ b/test/components/themes/parkland/sub_title_component_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Themes::Parkland::SubTitleComponentTest < ViewComponent::TestCase
+  test "renders when sub-title is present" do
+    sub_title = "All the recent news from your golf club"
+    assert_match(
+      /All the recent news from your golf club/,
+      render_inline(Themes::Parkland::SubTitleComponent.new(sub_title: sub_title)).to_html
+    )
+  end
+end


### PR DESCRIPTION
## Proposed Changes

- Add a sub-title component for the parkland theme that can be reused across multiple components for the theme.
  
Closes #64
